### PR TITLE
Add initial Terraform configuration files for AWS resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,2 @@
+data "aws_caller_identity" "current" {
+}

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,84 @@
+output "ses_domain_identity_arn" {
+  description = "The ARN of the domain identity"
+  value       = aws_ses_domain_identity.default.arn
+}
+
+output "ses_domain_identity_verification_arn" {
+  description = "The ARN of the domain identity"
+  value       = aws_ses_domain_identity_verification.default.arn
+}
+
+output "artifact_git_ref" {
+  description = "Git commit hash corresponding to the artifact"
+  value       = module.artifact.git_ref
+}
+
+output "artifact_file" {
+  description = "Full path to the locally downloaded artifact"
+  value       = module.artifact.file
+}
+
+output "artifact_url" {
+  description = "URL corresponding to the artifact"
+  value       = module.artifact.url
+}
+
+output "artifact_base64sha256" {
+  description = "Base64 encoded SHA256 hash of the artifact file"
+  value       = module.artifact.base64sha256
+}
+
+output "lambda_iam_policy_id" {
+  description = "Lamnda IAM Policy ID"
+  value       = aws_iam_policy.lambda.id
+}
+
+output "lambda_iam_policy_name" {
+  description = "Lamnda IAM Policy name"
+  value       = aws_iam_policy.lambda.name
+}
+
+output "lambda_iam_policy_arn" {
+  description = "Lamnda IAM Policy ARN"
+  value       = aws_iam_policy.lambda.arn
+}
+
+output "lambda_function_arn" {
+  description = "Lamnda Function ARN"
+  value       = aws_lambda_function.default.arn
+}
+
+output "lambda_function_version" {
+  description = "Latest published version of the Lambda Function"
+  value       = aws_lambda_function.default.version
+}
+
+output "lambda_function_source_code_size" {
+  description = "The size in bytes of the Lambda Function .zip file"
+  value       = aws_lambda_function.default.source_code_size
+}
+
+output "s3_bucket_id" {
+  description = "Lamnda IAM Policy name"
+  value       = aws_s3_bucket.default.id
+}
+
+output "s3_bucket_arn" {
+  description = "Lamnda IAM Policy ARN"
+  value       = aws_s3_bucket.default.arn
+}
+
+output "s3_bucket_domain_name" {
+  description = "Lamnda IAM Policy ARN"
+  value       = aws_s3_bucket.default.bucket_domain_name
+}
+
+output "ses_receipt_rule_name" {
+  description = "The name of the SES receipt rule"
+  value       = aws_ses_receipt_rule.default.name
+}
+
+output "ses_receipt_rule_set_name" {
+  description = "The name of the SES receipt rule set"
+  value       = aws_ses_receipt_rule.default.rule_set_name
+}

--- a/s3.tf
+++ b/s3.tf
@@ -1,0 +1,61 @@
+resource "aws_s3_bucket" "default" {
+  #bridgecrew:skip=BC_AWS_S3_13:Skipping `Enable S3 Bucket Logging` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
+  #bridgecrew:skip=BC_AWS_S3_14:Skipping `Ensure all data stored in the S3 bucket is securely encrypted at rest` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
+  #bridgecrew:skip=CKV_AWS_52:Skipping `Ensure S3 bucket has MFA delete enabled` due to issue in terraform (https://github.com/hashicorp/terraform-provider-aws/issues/629).
+  bucket        = module.this.id
+  force_destroy = true
+
+  versioning {
+    enabled = var.versioning_enabled
+  }
+
+  dynamic "logging" {
+    for_each = var.access_log_bucket_name != "" ? [1] : []
+    content {
+      target_bucket = var.access_log_bucket_name
+      target_prefix = "logs/${module.this.id}/"
+    }
+  }
+
+  dynamic "server_side_encryption_configuration" {
+    for_each = var.s3_bucket_encryption_enabled ? [1] : []
+
+    content {
+      rule {
+        apply_server_side_encryption_by_default {
+          sse_algorithm = "AES256"
+        }
+      }
+    }
+  }
+
+  tags = module.this.tags
+}
+
+data "aws_iam_policy_document" "s3" {
+  statement {
+    sid = "GiveSESPermissionToWriteEmail"
+
+    effect = "Allow"
+
+    principals {
+      identifiers = ["ses.amazonaws.com"]
+      type        = "Service"
+    }
+
+    actions = ["s3:PutObject"]
+
+    resources = ["${aws_s3_bucket.default.arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "aws:Referer"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "default" {
+  bucket = aws_s3_bucket.default.id
+  policy = data.aws_iam_policy_document.s3.json
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,72 @@
+variable "relay_email" {
+  type        = string
+  description = "Email that used to relay from"
+}
+
+variable "forward_emails" {
+  type = map(list(string))
+
+  default = {
+    "ops@example.com" = ["destination@example.com"]
+  }
+
+  description = "Map of forward emails"
+}
+
+variable "domain" {
+  type        = string
+  description = "Root domain name"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS Region the SES should reside in"
+}
+
+variable "spf" {
+  type        = string
+  default     = "v=spf1 include:amazonses.com -all"
+  description = "DNS SPF record value"
+}
+
+variable "lambda_runtime" {
+  type        = string
+  description = "Lambda runtime"
+  default     = "nodejs12.x"
+}
+
+variable "artifact_url" {
+  type        = string
+  description = "URL template for the remote artifact"
+  default     = "https://artifacts.cloudposse.com/$$${module_name}/$$${git_ref}/$$${filename}"
+}
+
+variable "artifact_filename" {
+  type        = string
+  description = "Artifact filename"
+  default     = "lambda.zip"
+}
+
+variable "versioning_enabled" {
+  type        = bool
+  default     = true
+  description = "A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket"
+}
+
+variable "tracing_config_mode" {
+  type        = string
+  description = "Can be either PassThrough or Active. If PassThrough, Lambda will only trace the request from an upstream service if it contains a tracing header with 'sampled=1'. If Active, Lambda will respect any tracing header it receives from an upstream service."
+  default     = "PassThrough"
+}
+
+variable "access_log_bucket_name" {
+  type        = string
+  default     = ""
+  description = "Name of the S3 bucket where s3 access log will be sent to"
+}
+
+variable "s3_bucket_encryption_enabled" {
+  type        = bool
+  default     = true
+  description = "When set to 'true' the 'aws_s3_bucket' resource will have AES256 encryption enabled by default"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 0.13.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    template = {
+      source  = "cloudposse/template"
+      version = ">= 2.2"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 1.2"
+    }
+  }
+}


### PR DESCRIPTION
- Create main.tf to retrieve AWS caller identity
- Add output.tf for SES and artifact outputs
- Implement s3.tf for S3 bucket and policy configurations
- Define variables in variables.tf for configuration management
- Set up versions.tf for Terraform and provider requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled retrieval of AWS account identity.
  - Exposed key AWS resource details via new output configurations.
  - Introduced an S3 bucket setup featuring optional logging, versioning, and encryption.
  - Expanded customization with additional configuration parameters for email, domain, region, and more.
  - Established version and provider requirements to ensure compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->